### PR TITLE
Support for ed25519 keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Unify and add description to key view across user settings ([#13](https://github.com/scm-manager/scm-manager/pull/13))
+- Support ed25519 keys ([#16](https://github.com/scm-manager/scm-ssh-plugin/pull/16))
 
 ## 2.2.1 - 2020-11-06
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,24 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>2.2.0</version>
+      <version>2.5.1</version>
+    </dependency>
+
+    <!--
+    enable ed25519 support
+    https://github.com/apache/mina-sshd/blob/master/docs/dependencies.md#ed25519-java
+    -->
+    <dependency>
+      <groupId>net.i2p.crypto</groupId>
+      <artifactId>eddsa</artifactId>
+      <version>0.3.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/cloudogu/scm/ssh/command/ScmCommand.java
+++ b/src/main/java/com/cloudogu/scm/ssh/command/ScmCommand.java
@@ -110,7 +110,10 @@ public class ScmCommand extends AbstractCommandSupport {
   }
 
   private int executeSimpleCommand(SimpleCommand simpleCommand, String command) throws IOException {
-    int exitCode = simpleCommand.execute(new SimpleCommandContext(command, in, out, err));
+    SimpleCommandContext context = new SimpleCommandContext(
+      command, getInputStream(), getOutputStream(), getErrorStream()
+    );
+    int exitCode = simpleCommand.execute(context);
     LOG.debug("finished execution of command '{}'", command);
     return exitCode;
   }
@@ -118,7 +121,9 @@ public class ScmCommand extends AbstractCommandSupport {
   private void executeProtocolCommand(CommandInterpreter commandInterpreter, String command) throws IOException {
     String[] args = commandInterpreter.getParsedArgs();
     RepositoryContext repositoryContext = commandInterpreter.getRepositoryContextResolver().resolve(args);
-    CommandContext commandContext = new CommandContext(command, args, in, out, err);
+    CommandContext commandContext = new CommandContext(
+      command, args, getInputStream(), getOutputStream(), getErrorStream()
+    );
     commandInterpreter.getProtocolHandler().handle(commandContext, repositoryContext);
     LOG.debug("finished protocol handling of command '{}'", command);
   }

--- a/src/test/java/com/cloudogu/scm/ssh/command/ScmCommandTest.java
+++ b/src/test/java/com/cloudogu/scm/ssh/command/ScmCommandTest.java
@@ -24,9 +24,9 @@
 package com.cloudogu.scm.ssh.command;
 
 import com.cloudogu.scm.ssh.simplecommand.SimpleCommandFactory;
-import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.util.threads.CloseableExecutorService;
 import org.apache.sshd.server.ExitCallback;
+import org.apache.sshd.server.session.ServerSession;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -48,11 +48,7 @@ import java.util.Optional;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ScmCommandTest {
@@ -62,7 +58,7 @@ class ScmCommandTest {
   @Mock
   private ScmCommandProtocol gitCommandProtocol;
   @Mock
-  private Session session;
+  private ServerSession session;
   @Mock
   private ExitCallback exitCallback;
   @Mock
@@ -135,12 +131,10 @@ class ScmCommandTest {
   }
 
   ScmCommand initTestObject(String command) {
-    ScmCommand scmCommand = new ScmCommand(command, executorService, singleton(commandInterpreterFactory), singleton(simpleCommandFactory)) {
-      @Override
-      public Session getSession() {
-        return session;
-      }
-    };
+    ScmCommand scmCommand = new ScmCommand(
+      command, executorService, singleton(commandInterpreterFactory), singleton(simpleCommandFactory)
+    );
+    scmCommand.setSession(session);
     scmCommand.setExitCallback(exitCallback);
     scmCommand.setInputStream(inputStream);
     scmCommand.setOutputStream(outputStream);


### PR DESCRIPTION
## Proposed changes

Add support for [ed25519](https://tools.ietf.org/html/draft-bjh21-ssh-ed25519-02) ssh keys.

https://groups.google.com/u/1/g/scmmanager/c/0tWi9MZwQ4Q/m/lE8ZOfT2CAAJ

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
