### PR TITLE
Replace custom styling with link styled button

### DIFF
--- a/gradle/changelog/replace_custom_styling.yaml
+++ b/gradle/changelog/replace_custom_styling.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Replace custom styling with link styled button ([#38](https://github.com/scm-manager/scm-ssh-plugin/pull/38))

--- a/src/main/js/AuthorizedKeyRow.tsx
+++ b/src/main/js/AuthorizedKeyRow.tsx
@@ -23,8 +23,9 @@
  */
 import React from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
+import styled from "styled-components";
+import { apiClient, DateFromNow, Loading, Button } from "@scm-manager/ui-components";
 import { AuthorizedKey } from "./types";
-import { apiClient, DateFromNow, Loading, Icon } from "@scm-manager/ui-components";
 import { formatAuthorizedKey } from "./formatAuthorizedKey";
 
 type Props = WithTranslation & {
@@ -35,6 +36,11 @@ type Props = WithTranslation & {
 type State = {
   loading: boolean;
 };
+
+const VCenteredTd = styled.td`
+  display: table-cell;
+  vertical-align: middle !important;
+`;
 
 class AuthorizedKeyRow extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -73,12 +79,12 @@ class AuthorizedKeyRow extends React.Component<Props, State> {
     const { authorizedKey } = this.props;
     return (
       <tr>
-        <td>{authorizedKey.displayName}</td>
-        <td>
+        <VCenteredTd>{authorizedKey.displayName}</VCenteredTd>
+        <VCenteredTd>
           <DateFromNow date={authorizedKey.created} />
-        </td>
-        <td className="is-hidden-mobile">{formatAuthorizedKey(authorizedKey.raw)}</td>
-        <td className="is-darker">{this.renderDeleteAction()}</td>
+        </VCenteredTd>
+        <VCenteredTd className="is-hidden-mobile">{formatAuthorizedKey(authorizedKey.raw)}</VCenteredTd>
+        <VCenteredTd>{this.renderDeleteAction()}</VCenteredTd>
       </tr>
     );
   }
@@ -93,11 +99,13 @@ class AuthorizedKeyRow extends React.Component<Props, State> {
         return <Loading />;
       }
       return (
-        <a className="level-item" onClick={() => this.onDelete(link.href)}>
-          <span className="icon">
-            <Icon name="trash" title={t("scm-ssh-plugin.delete")} color="inherit" />
-          </span>
-        </a>
+        <Button
+          color="text"
+          icon="trash"
+          action={() => this.onDelete(link.href)}
+          title={t("scm-ssh-plugin.delete")}
+          className="px-2"
+        />
       );
     }
     return null;


### PR DESCRIPTION
## Proposed changes
Replace custom styling with link styled button, see https://github.com/scm-manager/scm-manager/pull/2016

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
