### PR TITLE
Upgrade apache sshd library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,11 @@
  */
 
 plugins {
-  id 'org.scm-manager.smp' version '0.10.1'
+  id 'org.scm-manager.smp' version '0.11.1'
 }
 
 dependencies {
-  implementation "org.apache.sshd:sshd-core:2.5.1"
+  implementation "org.apache.sshd:sshd-core:2.8.0"
   implementation "net.i2p.crypto:eddsa:0.3.0"
   testImplementation "org.awaitility:awaitility:3.0.0"
 }

--- a/gradle/changelog/sshd_update.yaml
+++ b/gradle/changelog/sshd_update.yaml
@@ -1,0 +1,3 @@
+- type: fixed
+  description: Authorized key authentication with Ubuntu 22.04 (upgrade of apache sshd library, [#45](https://github.com/scm-manager/scm-ssh-plugin/pull/45))
+

--- a/src/main/java/com/cloudogu/scm/ssh/command/ScmCommandFactory.java
+++ b/src/main/java/com/cloudogu/scm/ssh/command/ScmCommandFactory.java
@@ -26,6 +26,7 @@ package com.cloudogu.scm.ssh.command;
 import com.cloudogu.scm.ssh.SshServerConfigurator;
 import com.cloudogu.scm.ssh.simplecommand.SimpleCommandFactory;
 import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.AbstractDelegatingCommandFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,12 +50,12 @@ public class ScmCommandFactory extends AbstractDelegatingCommandFactory implemen
   }
 
   @Override
-  public boolean isSupportedCommand(String command) {
+  public boolean isSupportedCommand(ChannelSession channel, String command) {
     return true;
   }
 
   @Override
-  protected ScmCommand executeSupportedCommand(String command) {
+  protected ScmCommand executeSupportedCommand(ChannelSession channel, String command) {
     LOG.debug("create scm command for '{}'", command);
     return new ScmCommand(command, Executors.get(), commandInterpreterFactories, simpleCommandFactories);
   }


### PR DESCRIPTION
## Proposed changes

Updates the apache sshd library to version 2.9.0.
Doing so, SCM-Manager will support other algorithms than
the deprecated SHA-1, so that authorized key authentication
works again for updated distributions like Ubuntu 22.04.

Fixes #44 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
